### PR TITLE
fix: only teams from the BitDAO GitHub organisation

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -9,9 +9,7 @@
 
 
 # Global code owner (WindRanger core team)
-*           @windranger-io/windranger-core
 *           @bitdao-io/windranger-core
 
 # GitHub Actions owners
-/.github/   @windranger-io/windranger-devops
 /.github/   @bitdao-io/windranger-devops


### PR DESCRIPTION
The little shield icon (when viewing a file in GitHub) denoting the code owners, does not apply to `/.github` ...maybe this fixes it?

Either way, keeping ownership restricted to be members of this repo's Organisation is a clearer separation of responsibility (allows for more granular security when scaling the teams 😉 ).