### PR TITLE
fix: ignore WebStorm/Intellij IDE project files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,3 +26,6 @@ yarn-error.log*
 
 .env
 .npmrc
+
+# Intellij IDE
+.idea


### PR DESCRIPTION
The IntelliJ IDEs all use a `.idea`  directory to store project files within. 