### PR TITLE
ci: dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,11 @@
+---
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+  - package-ecosystem: "npm"
+    directory: "/"
+    schedule:
+      interval: "monthly"


### PR DESCRIPTION
Unsure whether you want dependabot running and raising PRs against this repo?

If you do, then this PR adds a configuration file for dependabot to update actions and npm/yarn dependencies (does require the `yarn.lock` in the repo, which this project has), with the current project setup the PRs will automatically be raised 😁 
